### PR TITLE
docs: Fix doc translations

### DIFF
--- a/api/props/README.md
+++ b/api/props/README.md
@@ -52,7 +52,7 @@ customElement.define("web-component", c(component));
 
 ## Simple statements
 
-Las declaraciones simples permiten asociar solo la validación de tipo.
+Simple statements allow setting just type validations.
 
 ```javascript
 component.props = {

--- a/api/virtualdom/advanced.md
+++ b/api/virtualdom/advanced.md
@@ -158,9 +158,11 @@ function component() {
 
 The objective of this feature is to retrieve slot and use it as a template from the webcomponent.
 
-## Hidratación desde SSR
+## SSR hydration
 
-Atomico permite la reutilización del DOM ya existente en el documento, esto se realiza al momento de la instancia del webcomponent definiendo una propiedad especial sobre la etiqueta a hidratar
+Atomico allows reusing existing DOM in the document. This is done during the
+webcomponent instatiation, by setting a special property in the tag to mark it
+for hydration.
 
 ```markup
 <my-webcomponent data-hydrate>
@@ -168,7 +170,7 @@ Atomico permite la reutilización del DOM ya existente en el documento, esto se 
 </my-webcomponent>
 ```
 
-El shadowDOM también puede ser hidratado ejemplo:
+This can be done for shadowDom too:
 
 ```markup
 <my-webcomponent data-hydrate>
@@ -182,7 +184,9 @@ El shadowDOM también puede ser hidratado ejemplo:
 ```
 
 {% hint style="info" %}
-El código expuesto aun no es parte del estándar, es una propuesta impulsada por el **Google Chrome** [https://web.dev/declarative-shadow-dom/](https://web.dev/declarative-shadow-dom/), para ser usada en todos los browser debe hacer uso de polyfills.
+These code samples are not part of the standard yet, so polyfills must be used to
+ensure that it works in all browsers.
+Read more about **Google Chrome**'s proposal here [https://web.dev/declarative-shadow-dom/](https://web.dev/declarative-shadow-dom/).
 {% endhint %}
 
 ## Class name inheritance

--- a/guides/atomico-and-react/from-react-to-atomico/README.md
+++ b/guides/atomico-and-react/from-react-to-atomico/README.md
@@ -11,7 +11,7 @@ description: >-
 1. **Atomico will not limit your React learning curve**, what you learned in Atomico is applicable in React, for example hooks and virtualDOM.
 2. **Atomico is 3kB** in size which is 7% of React + React-dom.
 3. **Better component abstraction**, for example the use of the ShadowDOM will avoid the need to use css-in-js like styles-components or emotion, reducing dependencies.
-4. **Agnostic Components**, what you create with React only works within React, what you create with Atomico works on the web, so you can your components within React, Vue, Svelte or Html.
+4. **Agnostic Components**, what you create with React only works within React, what you create with Atomico works on the web, so you can use your components within React, Vue, Svelte or Html.
 5. **Exclusive component for React**, the CLI @ atomico / exports automatically generates a wrapper component of your webcomponent for React, improving backward compatibility with React.
 
 The following examples show some differences between React and Atomico.

--- a/guides/atomico-with-typescript/README.md
+++ b/guides/atomico-with-typescript/README.md
@@ -18,7 +18,7 @@ With Atomico and Typescript you will be able to:
 
 1. JSX runtime, Typescript will automatically import Atomico upon detecting the use of TSX.
 2. Autocompletion and validation of attributes, properties and events of tags and webcomponents.
-3. Validacion de instancia de webcomponents usando constructores.
+3. Webcomponent instance validation using constructors.
 
 ## Construct the props parameter of your functional component.
 

--- a/guides/tips.md
+++ b/guides/tips.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  La siguiente guía define algunos Tips a considerar al momento de crear
-  webcomponents con Atomico
+  Here are some tips you can take into account when creating webcomponents with Atomico
 ---
 
 # Tips


### PR DESCRIPTION
## What does this PR do?
It fixes some English translations where the Spanish content was shown.

## Where should the reviewer start?
The affected files are:
- api/props/README.md
- api/virtualdom/advanced.md
- guides/atomico-and-react/from-react-to-atomico/README.md
- guides/atomico-with-typescript/README.md
- guides/tips.md

## How do you feel with this PR?
I have tried to keep the same tone used through the docs, though I am not
sure if it is as preferred.
