### PR TITLE
docs: update `slot-as-templates.md` with current `usePromise` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ customElements.define("my-component", c(component));
 
 Atomico simplifies learning, workflow and maintenance when creating webcomponents and achieves it with:
 
-1. **scalable and reusable interfaces**: with Atomico the code is simpler and you can apply practices that facilitate the reuse of your code.
+1. **Scalable and reusable interfaces**: with Atomico the code is simpler and you can apply practices that facilitate the reuse of your code.
 2. **Open communication**: with Atomico you can communicate states by events, properties or methods.
 3. **Agnostic**: your custom Element will work in any web-compatible library, eg React, Vue, Svelte or Angular.
 4. **Performance**: Atomico has a comparative performance at Svelte levels, winning the third position in performance according to [**webcomponents.dev**](https://twitter.com/atomicojs/status/1391775734641745929) in a comparison of 55 libraries among which is React, Vue, Stencil and Lit.
 
-### Api
+### API
 
 {% content-ref url="api/props/" %}
 [props](api/props/)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,7 +10,7 @@
   * [You can create mobile applications](what-can-you-do-with-atomico/you-can-create-mobile-applications.md)
   * [You can create web applications](what-can-you-do-with-atomico/you-can-create-web-applications.md)
 
-## Api
+## API
 
 * [🧬 Props(Properties)](api/props/README.md)
   * [Value cycle as prop](api/props/value-cycle-as-prop.md)

--- a/api/hooks/usepromise.md
+++ b/api/hooks/usepromise.md
@@ -11,8 +11,8 @@ The purpose of this hook is to facilitate the consumption of promises.
 ```tsx
 import { usePromise } from "atomico";
 
-const callback = (id: number)=>Promise.resolve(id);
-const args:Parameters<typeof callback> = [1];
+const callback = (id: number) => Promise.resolve(id);
+const args: Parameters<typeof callback> = [1];
 const autorun = true;
 
 const promise = usePromise( callback, args, autorun );
@@ -25,7 +25,7 @@ where:
 * `autorun`: by default true, it automatically executes the promise, if it is false the execution of the promise is suspended.
 * `promise` : return object, at the type level it defines the following properties:
   * `pending`: boolean, defines if the promise is executed but pending resolution.
-  * `fulfilled`: boolean , defines if the promise has been fulfilled
+  * `fulfilled`: boolean, defines if the promise has been fulfilled
   * `result`: result of the promise.
   * `rejected`: boolean, defines if the promise has been rejected.
 

--- a/guides/atomico-design-patterns/slot-as-templates.md
+++ b/guides/atomico-design-patterns/slot-as-templates.md
@@ -2,7 +2,7 @@
 
 ### Introduction
 
-Slots are a powerful feature when working with webcomponents that use the shadowDOM and thanks to the hook `@atomico/hooks/use-slot` you will be able to observe the state of the slot and know the childNodes of this to manage the logic of the template, example:
+Slots are a powerful feature when working with webcomponents that use the shadowDOM. And thanks to the hook `@atomico/hooks/use-slot` you will be able to observe the state of the slot and know the childNodes of this to manage the logic of the template. For example:
 
 ```jsx
 import { useRef } from "atomico";
@@ -64,18 +64,18 @@ useSlot(refSlotSlides).filter(
 Slots are not only limited to a static definition, you can use them to identify a node and use it to create new nodes according to the logic of the webcomponent, example:
 
 ```jsx
-import { useRef } from "atomico";
+import { useRef, usePromise } from "atomico";
 import { useSlot } from "@atomico/hooks/use-slot";
-import { usePromise } from "@atomico/hooks/use-promise";
 
 function userFetch() {
   const refSlotTemplateUser = useRef();
   const [Template] = useSlot(refSlotTemplateUser);
-  const [result, status] = usePromise(
+  const promise = usePromise(
     () =>
       fetch("https://jsonplaceholder.typicode.com/users").then((res) =>
         res.json()
       ),
+    [],
     true
   );
 
@@ -83,9 +83,9 @@ function userFetch() {
     <host shadowDom>
       <slot name="template" ref={refSlotTemplateUser} />
       <div class="list">
-        {status === "fulfilled"
+        {promise.fulfilled
           ? !!Template &&
-            result.map((props) => <Template {...props} cloneNode />)
+            promise.result.map((props) => <Template {...props} cloneNode />)
           : "Pending..."}
       </div>
     </host>

--- a/guides/atomico-design-patterns/slot.md
+++ b/guides/atomico-design-patterns/slot.md
@@ -27,15 +27,15 @@ With Atomico you can define a default slot for your components, this is useful i
 </my-component>
 ```
 
-To define a default slot you only have to declare the prop slot in the props, example:
+To define a default slot, you only have to declare `slot` in the props, example:
 
 ```javascript
 myComponentHeader.props = {
-    slot: { type:String, value: "header"}
+    slot: { type: String, value: "header" }
 }
 
 myComponentFooter.props = {
-    slot: { type:String, value: "footer"}
+    slot: { type: String, value: "footer" }
 }
 ```
 
@@ -49,14 +49,14 @@ Atomico has the hook [**@atomico/hooks/use-slot**](../../packages/atomico-hooks/
 import { useRef } from "atomico";
 import { useSlot } from "@atomico/hooks/use-slot";
 
-function component(){
+function component() {
     const ref = useRef();
     const childNodes = useSlot(ref);
     return <host shadowDom>
         <header style={{
             display: childNodes.length? "block": "none"
         }}>
-            <slot name="header" ref={ref}/>
+            <slot name="header" ref={ref} />
         </header>
     </host>
 }

--- a/packages/atomico-store/README.md
+++ b/packages/atomico-store/README.md
@@ -118,7 +118,7 @@ export default new Store(Actions.initialStore, { actions: { Actions } });
 {% endtab %}
 {% endtabs %}
 
-### Api
+### API
 
 {% content-ref url="store.md" %}
 [store.md](store.md)

--- a/packages/deprecated/atomico-magic-form/README.md
+++ b/packages/deprecated/atomico-magic-form/README.md
@@ -103,7 +103,7 @@ function component() {
 
 `magic-form-provider` captures all the forms nested in `magic-form` when executing the submit event by the form and distributes them according to the definition of the action attribute to each method of the actions object
 
-### Api
+### API
 
 {% content-ref url="magicformprovider-or-less-than-magic-form-provider-greater-than.md" %}
 [magicformprovider-or-less-than-magic-form-provider-greater-than.md](magicformprovider-or-less-than-magic-form-provider-greater-than.md)

--- a/packages/deprecated/atomico-magic-form/magicform-patterns.md
+++ b/packages/deprecated/atomico-magic-form/magicform-patterns.md
@@ -12,7 +12,7 @@ description: >-
 async login(form: HTMLFormElement){
   const user = Object.fromEntries(new FormData(form) as any);
   
-  return myAPI.login(user);
+  return myApi.login(user);
 }
 ```
 

--- a/packages/deprecated/atomico-magic-form/magicform-patterns.md
+++ b/packages/deprecated/atomico-magic-form/magicform-patterns.md
@@ -12,7 +12,7 @@ description: >-
 async login(form: HTMLFormElement){
   const user = Object.fromEntries(new FormData(form) as any);
   
-  return myApi.login(user);
+  return myAPI.login(user);
 }
 ```
 


### PR DESCRIPTION
Hola! I am learning about atomicojs, as a possible Webcomponent solution for a project of mine.

I found some inaccuracies in the `slot-as-templates` docs, so this PR fixes them.

I discovered these errors in the Webcomponents.dev workspace https://studio.webcomponents.dev/edit/w2hdZpjAG1V3K8TxdBw0/src/component-user-fetch.jsx?p=stories

The source code there also needs to be fixed.

I also did some additional copyediting, if that is okay.


Thanks!