### PR TITLE
fix: call decorator function in Storybook preview.js

### DIFF
--- a/guides/atomico-and-storybook/README.md
+++ b/guides/atomico-and-storybook/README.md
@@ -23,7 +23,7 @@ Easily render webcomponents created with Atomico inside storytbook stories.&#x20
 ```typescript
 import { decorator } from "@atomico/storybook";
 
-export const decorators = [decorator];
+export const decorators = [decorator()];
 ```
 
 ### define


### PR DESCRIPTION
On https://atomico.gitbook.io/doc/packages/atomico-storybook, there is correct way to init Atomico Storybook decorator, however on https://atomico.gitbook.io/doc/guides/atomico-and-storybook, there is no decorator function call mentioned. For a moment, this discrepancy kept me busy while setting up Storybook for Atomico components :)